### PR TITLE
feat: update sizes attribute on image resize with new value

### DIFF
--- a/docs/api/lazy-load.md
+++ b/docs/api/lazy-load.md
@@ -63,6 +63,13 @@ interface UnLazyLoadOptions {
   placeholderSize?: number
 
   /**
+   * Whether to update the `sizes` attribute on resize events with the current image width.
+   *
+   * @default false
+   */
+  updateSizesOnResize?: boolean
+
+  /**
    * A callback function to run when an image is loaded.
    */
   onImageLoad?: (image: HTMLImageElement) => void

--- a/packages/core/src/lazyLoad.ts
+++ b/packages/core/src/lazyLoad.ts
@@ -157,7 +157,7 @@ export function createPlaceholderFromHash(
 
 // keeps track of elements that have a `data-sizes="auto"` attribute
 // and need to be updated when their size changes
-const resizeElementRepository = new Array<HTMLImageElement | HTMLSourceElement>()
+const resizeElementStore = new Set<HTMLImageElement | HTMLSourceElement>()
 
 function updateSizesAttribute(element: HTMLImageElement | HTMLSourceElement) {
   const { sizes } = element.dataset
@@ -171,13 +171,12 @@ function updateSizesAttribute(element: HTMLImageElement | HTMLSourceElement) {
   if (width)
     element.sizes = `${width}px`
 
-  const doesElementRecalculateOnResize = resizeElementRepository.includes(element)
-  if (doesElementRecalculateOnResize)
+  if (resizeElementStore.has(element))
     return
 
   const debounceResize = debounce(() => updateSizesAttribute(element), 500)
   const resizeObserver = new ResizeObserver(debounceResize)
-  resizeElementRepository.push(element)
+  resizeElementStore.add(element)
   resizeObserver.observe(element)
 }
 

--- a/packages/core/src/lazyLoad.ts
+++ b/packages/core/src/lazyLoad.ts
@@ -155,6 +155,10 @@ export function createPlaceholderFromHash(
   }
 }
 
+// keeps track of elements that have a `data-sizes="auto"` attribute
+// and need to be updated when their size changes
+const resizeElementRepository = new Array<HTMLImageElement | HTMLSourceElement>;
+
 function updateSizesAttribute(element: HTMLImageElement | HTMLSourceElement) {
   const { sizes } = element.dataset
   if (sizes !== 'auto')
@@ -166,6 +170,14 @@ function updateSizesAttribute(element: HTMLImageElement | HTMLSourceElement) {
 
   if (width)
     element.sizes = `${width}px`
+
+  const doesElementRecalculateOnResize = resizeElementRepository.includes(element)
+  if (doesElementRecalculateOnResize)
+    return
+
+  const resizeObserver = new ResizeObserver(() => updateSizesAttribute(element))
+  resizeObserver.observe(element)
+  resizeElementRepository.push(element)
 }
 
 function updateImageSrc(image: HTMLImageElement | HTMLSourceElement) {

--- a/packages/core/src/lazyLoad.ts
+++ b/packages/core/src/lazyLoad.ts
@@ -18,6 +18,7 @@ export function lazyLoad<T extends HTMLImageElement>(
     hash = true,
     hashType = 'blurhash',
     placeholderSize = DEFAULT_PLACEHOLDER_SIZE,
+    updateSizesOnResize = false,
     onImageLoad,
   }: UnLazyLoadOptions = {},
 ) {
@@ -26,13 +27,13 @@ export function lazyLoad<T extends HTMLImageElement>(
   for (const image of toElementArray<T>(selectorsOrElements)) {
     // Calculate the image's `sizes` attribute if `data-sizes="auto"` is set
     cleanupFns.add(
-      updateSizesAttribute(image, true),
+      updateSizesAttribute(image, updateSizesOnResize),
     )
 
     // Calculate the `sizes` attribute for sources inside a `<picture>` element
     if (image.parentElement?.tagName.toLowerCase() === 'picture') {
       [...image.parentElement.getElementsByTagName('source')].forEach(
-        sourceTag => updateSizesAttribute(sourceTag, false),
+        sourceTag => updateSizesAttribute(sourceTag),
       )
     }
 
@@ -160,7 +161,7 @@ export function createPlaceholderFromHash(
   }
 }
 
-// keeps track of elements that have a `data-sizes="auto"` attribute
+// Keep track of elements that have a `data-sizes="auto"` attribute
 // and need to be updated when their size changes
 const resizeElementStore = new WeakMap<HTMLImageElement | HTMLSourceElement, ResizeObserver>()
 

--- a/packages/core/src/lazyLoad.ts
+++ b/packages/core/src/lazyLoad.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PLACEHOLDER_SIZE } from './constants'
-import { isCrawler, isLazyLoadingSupported, toElementArray } from './utils'
+import { debounce, isCrawler, isLazyLoadingSupported, toElementArray } from './utils'
 import { createPngDataUri as createPngDataUriFromThumbHash } from './thumbhash'
 import { createPngDataUri as createPngDataUriFromBlurHash } from './blurhash'
 import type { UnLazyLoadOptions } from './types'
@@ -157,7 +157,7 @@ export function createPlaceholderFromHash(
 
 // keeps track of elements that have a `data-sizes="auto"` attribute
 // and need to be updated when their size changes
-const resizeElementRepository = new Array<HTMLImageElement | HTMLSourceElement>;
+const resizeElementRepository = new Array<HTMLImageElement | HTMLSourceElement>()
 
 function updateSizesAttribute(element: HTMLImageElement | HTMLSourceElement) {
   const { sizes } = element.dataset
@@ -175,9 +175,10 @@ function updateSizesAttribute(element: HTMLImageElement | HTMLSourceElement) {
   if (doesElementRecalculateOnResize)
     return
 
-  const resizeObserver = new ResizeObserver(() => updateSizesAttribute(element))
-  resizeObserver.observe(element)
+  const debounceResize = debounce(() => updateSizesAttribute(element), 500)
+  const resizeObserver = new ResizeObserver(debounceResize)
   resizeElementRepository.push(element)
+  resizeObserver.observe(element)
 }
 
 function updateImageSrc(image: HTMLImageElement | HTMLSourceElement) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,6 +36,13 @@ export interface UnLazyLoadOptions {
   placeholderSize?: number
 
   /**
+   * Whether to update the `sizes` attribute on resize events with the current image width.
+   *
+   * @default false
+   */
+  updateSizesOnResize?: boolean
+
+  /**
    * A callback function to run when an image is loaded.
    */
   onImageLoad?: (image: HTMLImageElement) => void

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -42,13 +42,19 @@ export function base64ToBytes(value: string) {
   return new Uint8Array(decodedData)
 }
 
-export function debounce<F extends (...args: Parameters<F>) => ReturnType<F>>(
-  func: F,
-  waitFor: number,
-): (...args: Parameters<F>) => void {
-  let timeout: NodeJS.Timeout
-  return (...args: Parameters<F>): void => {
-    clearTimeout(timeout)
-    timeout = setTimeout(() => func(...args), waitFor)
+export function debounce<T extends (...args: any[]) => void>(
+  fn: T,
+  delay: number,
+) {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  return function (...args: Parameters<T>) {
+    if (timeout)
+      clearTimeout(timeout)
+
+    timeout = setTimeout(() => {
+      timeout = undefined
+      fn(...args)
+    }, delay)
   }
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -41,3 +41,14 @@ export function base64ToBytes(value: string) {
 
   return new Uint8Array(decodedData)
 }
+
+export function debounce<F extends (...args: Parameters<F>) => ReturnType<F>>(
+  func: F,
+  waitFor: number,
+): (...args: Parameters<F>) => void {
+  let timeout: NodeJS.Timeout
+  return (...args: Parameters<F>): void => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => func(...args), waitFor)
+  }
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

fixes: https://github.com/johannschopplich/unlazy/issues/14

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When resizing the browser window, some image sizes may change. 

Currently the `sizes` attribute of the image is not updated, when a resize occurs.
This pull request adds this feature to the library. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
