### PR TITLE
fix(core): respect `sizes` when preloading images

### DIFF
--- a/packages/core/src/lazyLoad.ts
+++ b/packages/core/src/lazyLoad.ts
@@ -100,16 +100,16 @@ export function loadImage(
   image: HTMLImageElement,
   onImageLoad?: (image: HTMLImageElement) => void,
 ) {
-  const imageLoader = new Image()
+  const imagePreLoader = new Image()
   const { srcset, src, sizes } = image.dataset
   if (srcset)
-    imageLoader.srcset = srcset
+    imagePreLoader.srcset = srcset
   if (src)
-    imageLoader.src = src
+    imagePreLoader.src = src
   if (sizes)
-    imageLoader.sizes = sizes
+    imagePreLoader.sizes = sizes
 
-  imageLoader.addEventListener('load', () => {
+  imagePreLoader.addEventListener('load', () => {
     updatePictureSources(image)
     updateImageSrcset(image)
     updateImageSrc(image)

--- a/packages/core/src/lazyLoad.ts
+++ b/packages/core/src/lazyLoad.ts
@@ -103,11 +103,9 @@ export function loadImage(
   const imagePreLoader = new Image()
   const { srcset, src, sizes } = image.dataset
   if (sizes) {
-    // make sure that we calculate the correct `sizes` attribute
-    // if the image has a `sizes` attribute set to `auto`
-    sizes === 'auto'
-      ? imagePreLoader.sizes = `${image.offsetWidth}px`
-      : imagePreLoader.sizes = sizes
+    // Calculate the correct `sizes` attribute if `data-sizes="auto"` is set
+    const width = getOffsetWidth(image)
+    imagePreLoader.sizes = (sizes === 'auto' && width) ? `${width}px` : sizes
   }
   if (srcset)
     imagePreLoader.srcset = srcset
@@ -186,9 +184,7 @@ export function updateSizesAttribute(element: HTMLImageElement | HTMLSourceEleme
   if (sizes !== 'auto')
     return removeResizeObserver
 
-  const width = element instanceof HTMLSourceElement
-    ? element.parentElement?.getElementsByTagName('img')[0]?.offsetWidth
-    : element.offsetWidth
+  const width = getOffsetWidth(element)
 
   if (width)
     element.sizes = `${width}px`
@@ -224,4 +220,10 @@ function updatePictureSources(image: HTMLImageElement) {
     [...picture.querySelectorAll<HTMLSourceElement>('source[data-srcset]')].forEach(updateImageSrcset);
     [...picture.querySelectorAll<HTMLSourceElement>('source[data-src]')].forEach(updateImageSrc)
   }
+}
+
+function getOffsetWidth(element: HTMLElement | HTMLSourceElement) {
+  return element instanceof HTMLSourceElement
+    ? element.parentElement?.getElementsByTagName('img')[0]?.offsetWidth
+    : element.offsetWidth
 }

--- a/packages/core/src/lazyLoad.ts
+++ b/packages/core/src/lazyLoad.ts
@@ -102,12 +102,17 @@ export function loadImage(
 ) {
   const imagePreLoader = new Image()
   const { srcset, src, sizes } = image.dataset
+  if (sizes) {
+    // make sure that we calculate the correct `sizes` attribute
+    // if the image has a `sizes` attribute set to `auto`
+    sizes === 'auto'
+      ? imagePreLoader.sizes = `${image.offsetWidth}px`
+      : imagePreLoader.sizes = sizes
+  }
   if (srcset)
     imagePreLoader.srcset = srcset
   if (src)
     imagePreLoader.src = src
-  if (sizes)
-    imagePreLoader.sizes = sizes
 
   imagePreLoader.addEventListener('load', () => {
     updatePictureSources(image)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Boy or boy did I have to search long for this one 😅

A customer reported that always the largest image variant is loaded on his website.
But the browser actually loaded two image variants: one correct and a false one (always the largest variant).
This is specially hard to catch, if you have a large set of images on your page.

The problem was that the `lazyLoad` function calls the `loadImage` function, which preloads the image and then updates the URL on the corresponding image tag. But the `loadImage` didn't check if `sizes="auto"` was used.

The fallback of no `sizes` attribute set on a image is always `100vw`, that's why the largest variant was chosen.

The second  image is loaded, because the sizes attribute on the DOM image node is kicking in and loading the correct image.

This pull request fixes this issue.

### Reproduction:

https://codepen.io/franesberger/pen/ZEVLLzY