### PR TITLE
fix: improve pagespeed by decreasing resize debounce timer

### DIFF
--- a/packages/core/src/lazyLoad.ts
+++ b/packages/core/src/lazyLoad.ts
@@ -201,7 +201,7 @@ function updateSizesAttribute(
 
   if (options?.updateOnResize) {
     if (!resizeElementStore.has(element)) {
-      const debounceResize = debounce(() => updateSizesAttribute(element), 500)
+      const debounceResize = debounce(() => updateSizesAttribute(element), 200)
       const observerInstance = new ResizeObserver(debounceResize)
       resizeElementStore.set(element, observerInstance)
       observerInstance.observe(element)


### PR DESCRIPTION
Google Pagespeed tells me, that my images are not the correct size, but only in desktop mode.
I think Google Pagespeed resizes the window and doesn't wait long enaugh for the debounce effect to "settle" and update the size attribute. 