### PR TITLE
fix: loaded event fired before image was fully loaded on nuxt

### DIFF
--- a/packages/nuxt/src/runtime/components/UnLazyImage.vue
+++ b/packages/nuxt/src/runtime/components/UnLazyImage.vue
@@ -110,8 +110,7 @@ watchEffect(() => {
   if (props.preload) {
     if (props.autoSizes)
       _autoSizes(target.value)
-    loadImage(target.value)
-    emit('loaded', target.value)
+    loadImage(target.value, image => emit('loaded', image))
     return
   }
 


### PR DESCRIPTION
fix: loaded event fired before image was fully loaded when preload is set on nuxt

### 🔗 Linked issue
- Issue #58 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using the Nuxt integration and component, `UnLazyImage` emits the proper `loaded` event after the image was loaded, as expected. 
If adding the `preload` attribute, the `loaded` event was sent before the image was fully loaded.
This change solves this issue and now the component will emit the `loaded` event after the image was fully loaded also if using the `preload` attribute.

Resolves #58 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
