### PR TITLE
fix: loaded event was not fired with preload for Vue

### DIFF
--- a/packages/vue/src/components/UnLazyImage.vue
+++ b/packages/vue/src/components/UnLazyImage.vue
@@ -45,7 +45,7 @@ watchEffect(() => {
   if (props.preload) {
     if (props.autoSizes)
       _autoSizes(target.value)
-    loadImage(target.value)
+    loadImage(target.value, image => emit('loaded', image))
     return
   }
 


### PR DESCRIPTION
Fix: loaded event was not fired with preload attribute in Vue

### 🔗 Linked issue

- Issue #49 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When using the Vue integration, the `loaded` event does not fire at all when adding the `preload` attribute to the component. 
This PR fixes that using the same code as in the Nuxt integration (Issue #58).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
