### PR TITLE
feat: allow overwriting `loading` prop

### DIFF
--- a/packages/nuxt/src/runtime/components/UnLazyImage.vue
+++ b/packages/nuxt/src/runtime/components/UnLazyImage.vue
@@ -47,6 +47,11 @@ const props = withDefaults(
     preload?: boolean
     /** Whether the ThumbHash or BlurHash should be decoded on the server. Overrides the global module configuration if set. */
     ssr?: boolean
+    /**
+     * Allows to specify the loading strategy of the image.
+     * @default 'lazy'
+     */
+    loading?: ImgHTMLAttributes['loading']
   }>(),
   {
     src: undefined,
@@ -61,6 +66,7 @@ const props = withDefaults(
     lazyLoad: true,
     preload: false,
     ssr: undefined,
+    loading: undefined,
   },
 )
 
@@ -147,7 +153,7 @@ onBeforeUnmount(() => {
       :data-src="src"
       :data-srcset="srcSet"
       :data-sizes="autoSizes ? 'auto' : undefined"
-      :loading="props.lazyLoad ? 'lazy' : 'eager'"
+      :loading="loading || (props.lazyLoad ? 'lazy' : 'eager')"
       @error="emit('error', $event)"
     >
   </picture>
@@ -159,7 +165,7 @@ onBeforeUnmount(() => {
     :data-src="src"
     :data-srcset="srcSet"
     :data-sizes="autoSizes ? 'auto' : undefined"
-    :loading="props.lazyLoad ? 'lazy' : 'eager'"
+    :loading="loading || (props.lazyLoad ? 'lazy' : 'eager')"
     @error="emit('error', $event)"
   >
 </template>

--- a/packages/nuxt/src/runtime/components/UnLazyImage.vue
+++ b/packages/nuxt/src/runtime/components/UnLazyImage.vue
@@ -147,7 +147,7 @@ onBeforeUnmount(() => {
       :data-src="src"
       :data-srcset="srcSet"
       :data-sizes="autoSizes ? 'auto' : undefined"
-      loading="lazy"
+      :loading="props.lazyLoad ? 'lazy' : 'eager'"
       @error="emit('error', $event)"
     >
   </picture>
@@ -159,7 +159,7 @@ onBeforeUnmount(() => {
     :data-src="src"
     :data-srcset="srcSet"
     :data-sizes="autoSizes ? 'auto' : undefined"
-    loading="lazy"
+    :loading="props.lazyLoad ? 'lazy' : 'eager'"
     @error="emit('error', $event)"
   >
 </template>

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -21,6 +21,11 @@ interface Props
   thumbhash?: string
   /** Optional image source URL for a custom placeholder image. Will be ignored if a BlurHash or ThumbHash is provided. */
   placeholderSrc?: string
+  /**
+   * Allows to specify the loading strategy of the image.
+   * @default 'lazy'
+   */
+  loading?: ImgHTMLAttributes<HTMLImageElement>['loading']
 }
 
 export function UnLazyImage({
@@ -31,6 +36,7 @@ export function UnLazyImage({
   thumbhash,
   placeholderSrc,
   placeholderSize,
+  loading = 'lazy',
   ...rest
 }: Props) {
   const target = useRef<HTMLImageElement | null>(null)
@@ -57,7 +63,7 @@ export function UnLazyImage({
       data-src={src}
       data-srcset={srcSet}
       data-sizes={autoSizes ? 'auto' : undefined}
-      loading="lazy"
+      loading={loading}
       {...rest}
     />
   )

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -21,12 +21,17 @@ interface Props
   thumbhash?: string
   /** Optional image source URL for a custom placeholder image. Will be ignored if a BlurHash or ThumbHash is provided. */
   placeholderSrc?: string
+  /**
+   * Allows to specify the loading strategy of the image.
+   * @default 'lazy'
+   */
+  loading?: JSX.ImgHTMLAttributes<HTMLImageElement>['loading']
 }
 
 export function UnLazyImage(props: Props) {
   const [local, rest] = splitProps(
     props,
-    ['src', 'srcSet', 'autoSizes', 'blurhash', 'thumbhash', 'placeholderSrc', 'placeholderSize'],
+    ['src', 'srcSet', 'autoSizes', 'blurhash', 'thumbhash', 'placeholderSrc', 'placeholderSize', 'loading'],
   )
 
   const [target, setTarget] = createSignal<HTMLImageElement>()
@@ -54,7 +59,7 @@ export function UnLazyImage(props: Props) {
       data-src={local.src}
       data-srcset={local.srcSet}
       data-sizes={local.autoSizes ? 'auto' : undefined}
-      loading="lazy"
+      loading={local.loading || 'lazy'}
       {...rest}
     />
   )

--- a/packages/svelte/src/lib/UnLazyImage.svelte
+++ b/packages/svelte/src/lib/UnLazyImage.svelte
@@ -10,6 +10,7 @@
     thumbhash,
     placeholderSrc,
     placeholderSize,
+    loading = 'lazy',
     ...restProps
   }: {
     /** Image source URL to be lazy-loaded. */
@@ -29,6 +30,11 @@
     placeholderSrc?: string
     /** The size of the longer edge (width or height) of the BlurHash image to be decoded, depending on the aspect ratio. This option only applies when the `blurhash` prop is used. */
     placeholderSize?: number
+    /**
+     * Allows to specify the loading strategy of the image.
+     * @default 'lazy'
+     */
+    loading?: HTMLImgAttributes['loading']
   } & Omit<HTMLImgAttributes, 'srcset'> = $props()
 
   let target = $state<HTMLImageElement | undefined>()
@@ -55,6 +61,6 @@
   data-src={src}
   data-srcset={srcSet}
   data-sizes={autoSizes ? 'auto' : undefined}
-  loading='lazy'
+  {loading}
   {...restProps}
 />

--- a/packages/vue/src/components/UnLazyImage.vue
+++ b/packages/vue/src/components/UnLazyImage.vue
@@ -26,6 +26,11 @@ const props = defineProps<{
    * @default false
    */
   preload?: boolean
+  /**
+   * Allows to specify the loading strategy of the image.
+   * @default 'lazy'
+   */
+  loading?: ImgHTMLAttributes['loading']
 }>()
 
 const emit = defineEmits<{
@@ -69,7 +74,7 @@ onBeforeUnmount(() => {
     :data-src="src"
     :data-srcset="srcSet"
     :data-sizes="autoSizes ? 'auto' : undefined"
-    loading="lazy"
+    :loading="loading || 'lazy'"
     @error="emit('error', $event)"
   >
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/johannschopplich/unlazy/issues/62

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves an issue in the Nuxt Module so that it uses the lazyLoad prop to determine if the image should be lazyLoaded or not. Previously loading="lazy" was hardcoded.
